### PR TITLE
Fix build script (download into non-existing folder).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ RUN DEL c:\license.txt
 RUN DEL c:\start.ps1
 RUN DEL c:\dockerfile
 
-RUN PowerShell -Command Add-WindowsFeature Web-Server,web-AppInit,web-Asp-Net45,web-Windows-Auth,web-Dyn-Compression
+RUN Add-WindowsFeature Web-Server,web-AppInit,web-Asp-Net45,web-Windows-Auth,web-Dyn-Compression
 
+# HealthCheck should reflect in this case multiple services (if hosting severals in the container).
+# This actually breaks the best practices given by Docker.
 HEALTHCHECK CMD [ "sqlcmd", "-Q", "select 1" ]
 
 EXPOSE 1433 80 443 7045-7049

--- a/build.bat
+++ b/build.bat
@@ -1,3 +1,0 @@
-powershell -command Invoke-WebRequest -Uri "http://go.microsoft.com/fwlink/?LinkID=615137" -OutFile ".\Install\rewrite_amd64.msi"
-docker rmi navdocker.azurecr.io/nav/generic
-docker build -t navdocker.azurecr.io/nav/generic .

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,10 @@
+$installPath = Join-Path $PSScriptRoot 'Install'
+if (!(Test-Path $installPath))
+{
+    New-Item -ItemType Directory -Force $installPath
+}
+
+Invoke-WebRequest -Uri "http://go.microsoft.com/fwlink/?LinkID=615137" -OutFile (Join-Path $installPath 'rewrite_amd64.msi')
+
+docker rmi navdocker.azurecr.io/nav/generic
+docker build -t navdocker.azurecr.io/nav/generic .


### PR DESCRIPTION
Fix build script (download into a non-existing folder).
Use PowerShell instead of BAT.